### PR TITLE
Configs

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -5,7 +5,7 @@ class Configuration
   TEST_RESOURCES="src/test/resources"
   WEB_APP="src/main/webapp"
   WEB_INF="#{WEB_APP}/WEB-INF"
-  META_INF="#{WEB_INF}/META-INF"
+  META_INF="#{WEB_APP}/META-INF"
   FILENAME = "#{META_INF}/vraptor-scaffold.properties"
 
   def self.config

--- a/lib/generators/app_generator/app_generator.rb
+++ b/lib/generators/app_generator/app_generator.rb
@@ -37,8 +37,12 @@ class AppGenerator < VraptorScaffold::Base
 
   def configure_template_engine
     template("vraptor-scaffold.erb", Configuration::FILENAME)
+    template_engine.configure
+  end
+  
+  def template_engine
     templates = {"jsp" => JspTemplateEngine, "ftl" => FreemarkerTemplateEngine}
-    templates[options[:template_engine].to_s].new(project_path).configure
+    templates[options[:template_engine].to_s].new(project_path)
   end
 
   def create_test

--- a/lib/generators/app_generator/freemarker_template_engine.rb
+++ b/lib/generators/app_generator/freemarker_template_engine.rb
@@ -1,3 +1,4 @@
+require 'builder'
 class FreemarkerTemplateEngine < VraptorScaffold::Base
 
   def self.source_root
@@ -20,5 +21,14 @@ class FreemarkerTemplateEngine < VraptorScaffold::Base
 
   def extension
     "ftl"
+  end
+  
+  def dependencies
+    xml = Builder::XmlMarkup.new
+    xml.dependency do |d|
+      d.groupId "org.freemarker"
+      d.artifactId "freemarker"
+      d.version "2.3.16"
+    end
   end
 end

--- a/lib/generators/app_generator/jsp_template_engine.rb
+++ b/lib/generators/app_generator/jsp_template_engine.rb
@@ -20,4 +20,13 @@ class JspTemplateEngine < VraptorScaffold::Base
   def extension
     "jsp"
   end
+  
+  def dependencies
+    xml = Builder::XmlMarkup.new
+    xml.dependency do |d|
+      d.groupId "javax.servlet"
+      d.artifactId "jstl"
+      d.version "1.2"
+    end
+  end
 end

--- a/lib/generators/app_generator/templates/pom.erb
+++ b/lib/generators/app_generator/templates/pom.erb
@@ -12,6 +12,7 @@
 	</properties>
 	
 	<build>
+	  <outputDirectory>${basedir}/src/main/webapps/WEB-INF/classes</outputDirectory>
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/lib/generators/app_generator/templates/pom.erb
+++ b/lib/generators/app_generator/templates/pom.erb
@@ -12,7 +12,7 @@
 	</properties>
 	
 	<build>
-	  <outputDirectory>${basedir}/src/main/webapps/WEB-INF/classes</outputDirectory>
+	  <outputDirectory>${basedir}/src/main/webapp/WEB-INF/classes</outputDirectory>
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -84,11 +84,7 @@
 			<artifactId>sitemesh</artifactId>
 			<version>2.4.2</version>
 		</dependency>
-		<dependency>
-			<groupId>org.freemarker</groupId>
-			<artifactId>freemarker</artifactId>
-			<version>2.3.16</version>
-		</dependency>
+		<%=template_engine.dependencies%>
 		<dependency>
 			<groupId>javax.persistence</groupId>
 			<artifactId>persistence-api</artifactId>

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -27,7 +27,7 @@ describe Configuration do
   end
 
   it "should configure meta-inf" do
-    Configuration::META_INF.should == "#{Configuration::WEB_INF}/META-INF"
+    Configuration::META_INF.should == "#{Configuration::WEB_APP}/META-INF"
   end
 
   it "should configure properties name" do

--- a/spec/lib/generators/app_generator/app_generator_spec.rb
+++ b/spec/lib/generators/app_generator/app_generator_spec.rb
@@ -19,7 +19,7 @@ describe AppGenerator do
     it "should create pom" do
       from = File.expand_path(File.dirname(__FILE__) + "/templates/pom.xml")
       to = "#{@project_path}/pom.xml"
-      FileUtils.compare_file(from, to).should be_true
+      File.read(from).should == File.read(to)
     end
 
     context "creating main java" do
@@ -211,6 +211,10 @@ describe AppGenerator do
       to = "#{@webapp}/macros/html.ftl"
       FileUtils.compare_file(from, to).should be_true
     end
+    it "should include freemarker dependency" do
+      pom = "#{@project_path}/pom.xml"
+      File.read(pom).should match("<dependency><groupId>org.freemarker</groupId><artifactId>freemarker</artifactId><version>2.3.16</version></dependency>")
+    end
   end
   context "building a jsp application" do
     before(:all) do
@@ -255,6 +259,11 @@ describe AppGenerator do
     it "should not create path resolver" do
       to = "#{@app}/infrastructure/FreemarkerPathResolver.java"
       File.exist?(to).should be_false
+    end
+    
+    it "should include jstl dependency" do
+      pom = "#{@project_path}/pom.xml"
+      File.read(pom).should match("<dependency><groupId>javax.servlet</groupId><artifactId>jstl</artifactId><version>1.2</version></dependency>")
     end
 
   end

--- a/spec/lib/generators/app_generator/templates/pom.xml
+++ b/spec/lib/generators/app_generator/templates/pom.xml
@@ -12,6 +12,7 @@
 	</properties>
 	
 	<build>
+	  <outputDirectory>${basedir}/src/main/webapp/WEB-INF/classes</outputDirectory>
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -83,11 +84,7 @@
 			<artifactId>sitemesh</artifactId>
 			<version>2.4.2</version>
 		</dependency>
-		<dependency>
-			<groupId>org.freemarker</groupId>
-			<artifactId>freemarker</artifactId>
-			<version>2.3.16</version>
-		</dependency>
+		<dependency><groupId>javax.servlet</groupId><artifactId>jstl</artifactId><version>1.2</version></dependency>
 		<dependency>
 			<groupId>javax.persistence</groupId>
 			<artifactId>persistence-api</artifactId>

--- a/vraptor-scaffold.gemspec
+++ b/vraptor-scaffold.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
   s.authors = ["Rodolfo Liviero"]
-  s.date = %q{2010-09-02}
+  s.date = %q{2010-09-03}
   s.default_executable = %q{vraptor}
   s.description = %q{Scaffold for vraptor 3 with jpa, freemarker, maven, mockito, junit and jquery.}
   s.email = %q{rodolfoliviero@gmail.com}
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
      "lib/generators/app_generator/templates/src/controllers/.empty_directory",
      "lib/generators/app_generator/templates/src/models/Entity.java",
      "lib/generators/app_generator/templates/src/repositories/Repository.java",
-     "lib/generators/app_generator/templates/webapp/decorators/.empty_directory",
+     "lib/generators/app_generator/templates/vraptor-scaffold.erb",
      "lib/generators/app_generator/templates/webapp/images/.empty_directory",
      "lib/generators/app_generator/templates/webapp/index.jsp",
      "lib/generators/app_generator/templates/webapp/javascripts/jquery-1.4.2.min.js",


### PR DESCRIPTION
I added a pom configuration that removes the need for the vraptor start command line.
The regular mvn jetty:run works fine now.

freemarker and jstl dependencies are now added dynamically on the pom.xml, according to selected template engine.

using src/main/webapps/META-INF instead of src/main/webapps/WEB-INF/META-INF

[]'s
